### PR TITLE
fix: accept */* and add CORS on MCP route

### DIFF
--- a/app/api/mcp/route.ts
+++ b/app/api/mcp/route.ts
@@ -268,20 +268,45 @@ const handler = createMcpHandler(
   }
 );
 
-// Wrap handler to fix Accept header for MCP clients that don't send
-// text/event-stream (e.g. Claude) — mcp-handler returns 406 without it
-function withAcceptHeader(fn: (req: Request) => Promise<Response>) {
-  return (req: Request) => {
+const CORS_HEADERS: Record<string, string> = {
+  "access-control-allow-origin": "*",
+  "access-control-allow-methods": "GET, POST, DELETE, OPTIONS",
+  "access-control-allow-headers":
+    "content-type, accept, authorization, mcp-protocol-version, mcp-session-id",
+  "access-control-expose-headers": "mcp-session-id",
+  "access-control-max-age": "86400",
+};
+
+// Wrap handler to (1) fix Accept header for MCP clients that don't send
+// text/event-stream (e.g. Claude) — mcp-handler requires both
+// application/json AND text/event-stream explicitly listed, and rejects
+// Accept: */* with a 406; and (2) add CORS headers so browser-based MCP
+// clients can connect.
+function withMcpHeaders(fn: (req: Request) => Promise<Response>) {
+  return async (req: Request) => {
     const accept = req.headers.get("accept") || "";
-    if (!accept.includes("text/event-stream") && !accept.includes("*/*")) {
+    const hasJson = accept.includes("application/json");
+    const hasSse = accept.includes("text/event-stream");
+    if (!hasJson || !hasSse) {
       const headers = new Headers(req.headers);
       headers.set("accept", "application/json, text/event-stream");
       req = new Request(req, { headers });
     }
-    return fn(req);
+    const res = await fn(req);
+    const headers = new Headers(res.headers);
+    for (const [k, v] of Object.entries(CORS_HEADERS)) headers.set(k, v);
+    return new Response(res.body, {
+      status: res.status,
+      statusText: res.statusText,
+      headers,
+    });
   };
 }
 
-export const GET = withAcceptHeader(handler);
-export const POST = withAcceptHeader(handler);
-export const DELETE = withAcceptHeader(handler);
+export const GET = withMcpHeaders(handler);
+export const POST = withMcpHeaders(handler);
+export const DELETE = withMcpHeaders(handler);
+
+export function OPTIONS() {
+  return new Response(null, { status: 204, headers: CORS_HEADERS });
+}


### PR DESCRIPTION
## Summary

- Fix Accept-header shim to rewrite when either `application/json` or `text/event-stream` is missing. The prior version treated `Accept: */*` as acceptable and skipped the rewrite, but `mcp-handler` requires both media types to be explicitly listed and returns 406 otherwise. Clients sending `*/*` (including claude.ai's MCP connector) hit this and surfaced it as a generic "Failed to connect" / 502 in the UI.
- Add CORS headers and an `OPTIONS` preflight handler so browser-based MCP clients can connect. Exposes `mcp-session-id` so session tokens are readable.

## Test plan

- [ ] After deploy, POST to the endpoint with `Accept: */*` (curl default) returns 200 instead of 406.
- [ ] `OPTIONS` preflight from origin `https://claude.ai` returns 204 with `access-control-allow-*` headers.
- [ ] Re-add the connector in claude.ai and confirm it connects.
- [ ] Confirm Claude Desktop and Claude Code CLI still connect (they send correct Accept headers already).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
