### PR TITLE
fix(search): drop unpublished items from Algolia and rebuild orphans-clean

### DIFF
--- a/pages/api/search/indexAllArticles.js
+++ b/pages/api/search/indexAllArticles.js
@@ -11,8 +11,10 @@ const index = algoliaClient.initIndex("doc_site");
 export default async (req, res) => {
 
     
+    const startedAt = Date.now();
+
     const { data } = await client.query({
-        query: gql`    
+        query: gql`
         {
             doccategories  {
                 contentID
@@ -44,21 +46,28 @@ export default async (req, res) => {
                 }
               }
         }`,
+        // Always read fresh content for indexing — never serve from Apollo cache.
+        fetchPolicy: 'no-cache',
     });
-    
+
     const articleUrls = await getDynamicPageSitemapMappingREST();
 
     let objects = [];
+    const categoryBreakdown = [];
     for(const cat of data.doccategories) {
-        if(cat.fields.articles) {
-            for(const article of cat.fields.articles) {
-                const object = await normalizeArticle({
-                    article,
-                    url: articleUrls[article.contentID],
-                    category: cat
-                });
-                objects.push(object);
-            }
+        const articles = cat.fields.articles || [];
+        categoryBreakdown.push({
+            contentID: cat.contentID,
+            title: cat.fields.title,
+            articleCount: articles.length,
+        });
+        for(const article of articles) {
+            const object = await normalizeArticle({
+                article,
+                url: articleUrls[article.contentID],
+                category: cat
+            });
+            objects.push(object);
         }
     }
 
@@ -72,7 +81,15 @@ export default async (req, res) => {
     // so any record not in `objects` (deleted/unpublished/orphaned) is removed.
     await index.replaceAllObjects(objects, { safe: true });
 
-    res.status(200).json({ ok: true, count: objects.length });
+    res.status(200).json({
+        ok: true,
+        index: 'doc_site',
+        indexed: objects.length,
+        categories: categoryBreakdown.length,
+        durationMs: Date.now() - startedAt,
+        categoryBreakdown,
+        objectIDs: objects.map(o => o.objectID),
+    });
 };
 
 

--- a/pages/api/search/indexAllArticles.js
+++ b/pages/api/search/indexAllArticles.js
@@ -68,10 +68,11 @@ export default async (req, res) => {
         attributesToSnippet: ['body:30'],
     });
 
-    //save it in Algolia
-    await index.saveObjects(objects)
+    // Atomic full rebuild: replaceAllObjects copies into a temp index and renames,
+    // so any record not in `objects` (deleted/unpublished/orphaned) is removed.
+    await index.replaceAllObjects(objects, { safe: true });
 
-    res.status(200).json(true);
+    res.status(200).json({ ok: true, count: objects.length });
 };
 
 

--- a/pages/api/search/indexArticle.js
+++ b/pages/api/search/indexArticle.js
@@ -24,60 +24,65 @@ export default async (req, res) => {
     }
     const state = req.body.state;
 
-    if(contentID && state && state === 'Deleted') {
-        await index.deleteObject(contentID);
+    if(contentID && state && (state === 'Deleted' || state === 'Unpublished')) {
+        await index.deleteObject(`${contentID}`);
+        res.status(200).json({ deleted: contentID, state });
         return;
-    } else {
-    
-        const { data } = await client.query({
-            query: gql`    
-            {
-                ${referenceName} (contentID: ${contentID})  {
-                    contentID
-                    properties {
-                        itemOrder
-                    }
-                    fields {
-                        title
-                        content
-                        markdownContent
-                        description
-                        section {
-                            contentID
-                            fields {
-                                title
-                            }
+    }
+
+    const { data } = await client.query({
+        query: gql`
+        {
+            ${referenceName} (contentID: ${contentID})  {
+                contentID
+                properties {
+                    itemOrder
+                }
+                fields {
+                    title
+                    content
+                    markdownContent
+                    description
+                    section {
+                        contentID
+                        fields {
+                            title
                         }
-                        concept {
-                            contentID
-                            fields {
-                                title
-                            }
+                    }
+                    concept {
+                        contentID
+                        fields {
+                            title
                         }
                     }
                 }
-            }`,
-        });
-        
-        const article = data[referenceName][0];
+            }
+        }`,
+    });
 
-        const url = await getDynamicPageURL({
-            contentID: article.contentID,
-            preview: false
-        })
+    const article = data[referenceName] && data[referenceName][0];
 
-        const object = await normalizeArticle({
-            article,
-            url
-        })
-
-        //save it in Algolia
-        await index.saveObject(object)
-
-       
+    // If the article isn't returned by the published API, it's been unpublished/removed.
+    // Strip it from the index so search results stay in sync.
+    if(!article) {
+        await index.deleteObject(`${contentID}`);
+        res.status(200).json({ deleted: contentID, reason: 'not-published' });
+        return;
     }
 
-    res.status(200).json();
+    const url = await getDynamicPageURL({
+        contentID: article.contentID,
+        preview: false
+    })
+
+    const object = await normalizeArticle({
+        article,
+        url
+    })
+
+    await index.saveObject(object)
+
+    res.status(200).json({ saved: contentID });
 };
 
 

--- a/pages/api/search/indexArticle.js
+++ b/pages/api/search/indexArticle.js
@@ -58,6 +58,9 @@ export default async (req, res) => {
                 }
             }
         }`,
+        // Webhook fires immediately after a publish — bypass Apollo cache so we
+        // never index stale content.
+        fetchPolicy: 'no-cache',
     });
 
     const article = data[referenceName] && data[referenceName][0];


### PR DESCRIPTION
## Summary
- **Single-article webhook** ([pages/api/search/indexArticle.js](pages/api/search/indexArticle.js)): now treats both `Deleted` **and** `Unpublished` states as removals (was only `Deleted`). Adds a safety net: if the published GraphQL API returns no record for a contentID — typical when content was unpublished/removed without a clean state value — delete it from the index instead of crashing on `data[referenceName][0]`. Also returns proper JSON responses on every branch (the delete path was previously returning without sending a status).
- **Bulk rebuild** ([pages/api/search/indexAllArticles.js](pages/api/search/indexAllArticles.js)): switched from `saveObjects` (upsert-only) to `replaceAllObjects(..., { safe: true })`. Algolia copies into a temp index and atomically renames, so any record not in the current published set (deleted, unpublished, orphaned) is dropped on rebuild.

## Why
Reference: Agility content states are `1=Staging, 2=Published, 3=Deleted, 4=Approved, 5=AwaitingApproval, 6=Declined, 7=Unpublished`. Both `Deleted` and `Unpublished` should remove the record from search; previously only `Deleted` did. And because the bulk rebuild only upserted, the only way an orphan ever got cleaned out was by hand.

## Test plan
- [ ] Deploy to preview, then `POST /docs/api/search/indexAllArticles` — confirm `{ ok: true, count: N }` and that the live `doc_site` index size matches the published article count.
- [ ] In the CMS, unpublish an article and confirm the webhook removes it from search.
- [ ] Re-publish the article and confirm it reappears in search.
- [ ] Delete an article in the CMS and confirm the webhook removes it.
- [ ] Smoke-test search on the docs site after rebuild — golden-path queries still return expected hits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)