### PR TITLE
Render embedded HTML in markdown + steer MCP search_docs callers

### DIFF
--- a/app/api/mcp/route.ts
+++ b/app/api/mcp/route.ts
@@ -41,12 +41,29 @@ const handler = createMcpHandler(
   async (server) => {
     server.tool(
       "search_docs",
-      "Search the Agility CMS documentation. Returns matching articles with titles, URLs, descriptions, categories, and content snippets. Use the fetch_doc tool to get full article content for detailed analysis.",
+      [
+        "Search the Agility CMS documentation using concise semantic queries.",
+        "Do not use long keyword bundles. For broad, ambiguous, or multi-part questions, call search_docs multiple times with short related queries, each focused on one concept, synonym, or likely documentation phrase. Compare the returned articles and use fetch_doc on the most relevant results for detailed analysis.",
+        "",
+        "Good queries are usually 3 to 8 words or one short question.",
+        "",
+        "Examples:",
+        '- "content staging workflow"',
+        '- "manage content across environments"',
+        '- "deployment environments"',
+        '- "preview content before publishing"',
+        '- "CI/CD content synchronization"',
+        "",
+        "Avoid:",
+        '- "multiple environments devops content operations environments staging production development preview publishing workflow ci cd"',
+        "",
+        "If a search returns no or weak results, retry with shorter semantic alternatives before concluding that no documentation exists.",
+      ].join("\n"),
       {
         query: z
           .string()
           .describe(
-            "Search query string. Natural language queries work best."
+            "A concise semantic search query, usually 3 to 8 words or one short natural-language question. Search one concept at a time. For broad questions, call search_docs multiple times with short related queries instead of sending one long keyword list. Avoid keyword stuffing."
           ),
         page: z
           .number()
@@ -63,6 +80,41 @@ const handler = createMcpHandler(
       },
       async ({ query, page }: { query: string; page?: number }) => {
         const startTime = Date.now();
+
+        // Steer callers away from keyword-stuffed queries before they
+        // burn an Algolia call. Semantic search is recall-poor on long
+        // bundles; multiple short queries return better results.
+        const wordCount = query.trim().split(/\s+/).filter(Boolean).length;
+        const MAX_QUERY_WORDS = 12;
+        if (wordCount > MAX_QUERY_WORDS) {
+          const hint = [
+            `This query is too broad (${wordCount} words). Semantic search works best with short focused queries.`,
+            "",
+            "Retry with multiple shorter searches (3 to 8 words each), each targeting one concept, synonym, or likely documentation phrase. Compare the result sets and call fetch_doc on the most relevant articles.",
+            "",
+            "Example: instead of one keyword bundle, try short queries like:",
+            '- "content staging workflow"',
+            '- "deployment environments"',
+            '- "preview content before publishing"',
+          ].join("\n");
+
+          trackMcpToolCall(
+            "search_docs",
+            { query, page: page || 0, blocked: "query_too_long", wordCount },
+            Date.now() - startTime,
+            true
+          );
+
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: hint,
+              },
+            ],
+          };
+        }
+
         try {
           const algoliaStart = Date.now();
           const results = await index.search(query, {
@@ -252,7 +304,8 @@ const handler = createMcpHandler(
     capabilities: {
       tools: {
         search_docs: {
-          description: "Search Agility CMS documentation",
+          description:
+            "Search Agility CMS documentation using concise semantic queries. Prefer multiple short focused queries over long keyword bundles.",
         },
         fetch_doc: {
           description: "Retrieve full article content by ID",

--- a/components/agility-pageModules/DynamicArticleDetails.js
+++ b/components/agility-pageModules/DynamicArticleDetails.js
@@ -3,12 +3,20 @@ import Blocks from "../common/blocks/index";
 import axios from "axios";
 import nextConfig from "next.config";
 import { ToggleSwitch } from "components/common/ToggleSwitch";
-import { remark } from 'remark';
+import { unified } from 'unified';
+import remarkParse from 'remark-parse';
 import remarkGfm from 'remark-gfm';
 import remarkRehype from 'remark-rehype';
+import rehypeRaw from 'rehype-raw';
 import rehypeSlug from 'rehype-slug';
 import rehypeStringify from 'rehype-stringify';
 const hljs = require('highlight.js');
+
+function remarkDisableIndentedCode() {
+	const data = this.data();
+	const list = data.micromarkExtensions || (data.micromarkExtensions = []);
+	list.push({ disable: { null: ['codeIndented'] } });
+}
 
 // Custom component to render markdown with code highlighting
 const MarkdownContent = ({ htmlContent }) => {
@@ -49,6 +57,20 @@ const MarkdownContent = ({ htmlContent }) => {
 			if (pre && pre.tagName === 'PRE') {
 				pre.classList.add('hljs-pre');
 			}
+		});
+
+		// Browsers do not execute <script> tags inserted via innerHTML.
+		// Re-create each script element so embedded JS in CMS markdown actually runs.
+		const inertScripts = containerRef.current.querySelectorAll('script');
+		inertScripts.forEach((oldScript) => {
+			const newScript = document.createElement('script');
+			for (const attr of oldScript.attributes) {
+				newScript.setAttribute(attr.name, attr.value);
+			}
+			if (oldScript.textContent) {
+				newScript.textContent = oldScript.textContent;
+			}
+			oldScript.parentNode.replaceChild(newScript, oldScript);
 		});
 	}, [htmlContent]);
 
@@ -98,11 +120,14 @@ const DynamicArticleDetails = ({ module, dynamicPageItem, sitemapNode }) => {
 				markdownWithoutH1 = lines.slice(1).join('\n');
 			}
 
-			remark()
+			unified()
+				.use(remarkParse)
+				.use(remarkDisableIndentedCode)
 				.use(remarkGfm)
-				.use(remarkRehype)
+				.use(remarkRehype, { allowDangerousHtml: true })
+				.use(rehypeRaw)
 				.use(rehypeSlug)
-				.use(rehypeStringify)
+				.use(rehypeStringify, { allowDangerousHtml: true })
 				.process(markdownWithoutH1)
 				.then((processedContent) => {
 					let htmlContent = processedContent.toString();
@@ -144,8 +169,8 @@ const DynamicArticleDetails = ({ module, dynamicPageItem, sitemapNode }) => {
 			className="xl:flex xl:flex-row justify-center font-muli mb-32"
 		>
 
-			<div className="relative px-8">
-				<div className="text-lg max-w-prose mx-auto">
+			<div className="relative px-8 xl:px-12 w-full">
+				<div className="text-lg max-w-prose lg:max-w-3xl xl:max-w-4xl 2xl:max-w-5xl mx-auto">
 					<div className="flex justify-end gap-2 mt-5">
 						{showClassicMode &&
 							<ToggleSwitch

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "react-html-parser": "^2.0.2",
     "react-icons": "^4.2.0",
     "react-syntax-highlighter": "^15.4.4",
+    "rehype-raw": "^7.0.0",
     "rehype-slug": "^6.0.0",
     "rehype-stringify": "^10.0.1",
     "remark": "^15.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3097,6 +3097,11 @@ entities@^2.0.0:
   resolved "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz"
   integrity sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==
 
+entities@^6.0.0:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-6.0.1.tgz#c28c34a43379ca7f61d074130b2f5f7020a30694"
+  integrity sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==
+
 es-abstract@^1.17.5, es-abstract@^1.23.2, es-abstract@^1.23.3, es-abstract@^1.23.5, es-abstract@^1.23.6, es-abstract@^1.23.9:
   version "1.23.9"
   resolved "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.9.tgz"
@@ -4101,6 +4106,20 @@ hasown@^2.0.0, hasown@^2.0.2:
   dependencies:
     function-bind "^1.1.2"
 
+hast-util-from-parse5@^8.0.0:
+  version "8.0.3"
+  resolved "https://registry.yarnpkg.com/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz#830a35022fff28c3fea3697a98c2f4cc6b835a2e"
+  integrity sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    "@types/unist" "^3.0.0"
+    devlop "^1.0.0"
+    hastscript "^9.0.0"
+    property-information "^7.0.0"
+    vfile "^6.0.0"
+    vfile-location "^5.0.0"
+    web-namespaces "^2.0.0"
+
 hast-util-heading-rank@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/hast-util-heading-rank/-/hast-util-heading-rank-3.0.0.tgz"
@@ -4112,6 +4131,32 @@ hast-util-parse-selector@^2.0.0:
   version "2.2.5"
   resolved "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-2.2.5.tgz"
   integrity sha512-7j6mrk/qqkSehsM92wQjdIgWM2/BW61u/53G6xmC8i1OmEdKLHbk419QKQUjz6LglWsfqoiHmyMRkP1BGjecNQ==
+
+hast-util-parse-selector@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz#352879fa86e25616036037dd8931fb5f34cb4a27"
+  integrity sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==
+  dependencies:
+    "@types/hast" "^3.0.0"
+
+hast-util-raw@^9.0.0:
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/hast-util-raw/-/hast-util-raw-9.1.0.tgz#79b66b26f6f68fb50dfb4716b2cdca90d92adf2e"
+  integrity sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    "@types/unist" "^3.0.0"
+    "@ungap/structured-clone" "^1.0.0"
+    hast-util-from-parse5 "^8.0.0"
+    hast-util-to-parse5 "^8.0.0"
+    html-void-elements "^3.0.0"
+    mdast-util-to-hast "^13.0.0"
+    parse5 "^7.0.0"
+    unist-util-position "^5.0.0"
+    unist-util-visit "^5.0.0"
+    vfile "^6.0.0"
+    web-namespaces "^2.0.0"
+    zwitch "^2.0.0"
 
 hast-util-sanitize@^5.0.0:
   version "5.0.2"
@@ -4139,6 +4184,19 @@ hast-util-to-html@^9.0.0:
     stringify-entities "^4.0.0"
     zwitch "^2.0.4"
 
+hast-util-to-parse5@^8.0.0:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/hast-util-to-parse5/-/hast-util-to-parse5-8.0.1.tgz#95aa391cc0514b4951418d01c883d1038af42f5d"
+  integrity sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    comma-separated-tokens "^2.0.0"
+    devlop "^1.0.0"
+    property-information "^7.0.0"
+    space-separated-tokens "^2.0.0"
+    web-namespaces "^2.0.0"
+    zwitch "^2.0.0"
+
 hast-util-to-string@^3.0.0:
   version "3.0.1"
   resolved "https://registry.npmjs.org/hast-util-to-string/-/hast-util-to-string-3.0.1.tgz"
@@ -4163,6 +4221,17 @@ hastscript@^6.0.0:
     hast-util-parse-selector "^2.0.0"
     property-information "^5.0.0"
     space-separated-tokens "^1.0.0"
+
+hastscript@^9.0.0:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/hastscript/-/hastscript-9.0.1.tgz#dbc84bef6051d40084342c229c451cd9dc567dff"
+  integrity sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    comma-separated-tokens "^2.0.0"
+    hast-util-parse-selector "^4.0.0"
+    property-information "^7.0.0"
+    space-separated-tokens "^2.0.0"
 
 he@1.2.0:
   version "1.2.0"
@@ -5959,6 +6028,13 @@ parse-entities@^2.0.0:
     is-decimal "^1.0.0"
     is-hexadecimal "^1.0.0"
 
+parse5@^7.0.0:
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-7.3.0.tgz#d7e224fa72399c7a175099f45fc2ad024b05ec05"
+  integrity sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==
+  dependencies:
+    entities "^6.0.0"
+
 parseurl@^1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.3.tgz#9da19e7bee8d12dff0513ed5b76957793bc2e8d4"
@@ -6482,6 +6558,15 @@ regexpp@^3.1.0:
   version "3.2.0"
   resolved "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz"
   integrity sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==
+
+rehype-raw@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/rehype-raw/-/rehype-raw-7.0.0.tgz#59d7348fd5dbef3807bbaa1d443efd2dd85ecee4"
+  integrity sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    hast-util-raw "^9.0.0"
+    vfile "^6.0.0"
 
 rehype-slug@^6.0.0:
   version "6.0.0"
@@ -7619,6 +7704,14 @@ vary@^1, vary@^1.1.2:
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==
 
+vfile-location@^5.0.0:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/vfile-location/-/vfile-location-5.0.3.tgz#cb9eacd20f2b6426d19451e0eafa3d0a846225c3"
+  integrity sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==
+  dependencies:
+    "@types/unist" "^3.0.0"
+    vfile "^6.0.0"
+
 vfile-message@^4.0.0:
   version "4.0.3"
   resolved "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz"
@@ -7634,6 +7727,11 @@ vfile@^6.0.0:
   dependencies:
     "@types/unist" "^3.0.0"
     vfile-message "^4.0.0"
+
+web-namespaces@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/web-namespaces/-/web-namespaces-2.0.1.tgz#1010ff7c650eccb2592cebeeaf9a1b253fd40692"
+  integrity sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==
 
 webidl-conversions@^3.0.0:
   version "3.0.1"


### PR DESCRIPTION
## Summary

Two unrelated improvements to the docs site, bundled because they were caught in the same review pass:

1. **Render embedded HTML, styles, and scripts in markdown articles** — `<figure>`, `<svg>`, `<style>`, and `<script>` blocks now work inside editorial markdown. Previously raw HTML was escaped, indented HTML became code blocks, and `<script>` tags were inert.
2. **Steer MCP `search_docs` callers toward concise semantic queries** — long keyword bundles return weak Algolia results; the tool description, parameter description, and a new server-side guard now push callers toward several short focused queries.

---

## 1. Markdown HTML rendering

### What changed
- `remark-rehype` was escaping raw HTML by default. Added `rehype-raw` and `allowDangerousHtml: true` so HTML passes through.
- CommonMark turned 4-space-indented HTML (e.g. an `<svg>` inside a `<figure>`) into an indented code block. Disabled the `codeIndented` tokenizer; this site uses fenced (` ``` `) code blocks exclusively.
- Browsers refuse to execute `<script>` inserted via `innerHTML`. After render, `MarkdownContent` walks the container and replaces each `<script>` with a fresh `document.createElement('script')` so the JS actually runs.
- Article column max-width is now `max-w-prose` → `lg:max-w-3xl` → `xl:max-w-4xl` → `2xl:max-w-5xl`, with `xl:px-12` padding.

### Authoring caveat for reviewers
Embedded scripts re-execute on every render (e.g. when navigating between articles). Authors should keep them idempotent — IIFEs are fine; long-lived `setInterval` or global `window`/`document` listeners will leak across navigations because we have no clean teardown hook.

---

## 2. MCP `search_docs` guidance

### What changed
- **Tool-level description** now lays out the multi-query pattern with good/bad examples and tells callers to retry with shorter alternatives before concluding no documentation exists.
- **`query` parameter description** repeats the constraint at the field level (3–8 words; one concept per call).
- **Server-side guard**: queries with more than 12 words skip Algolia and return a steering hint instead. Tracked via `trackMcpToolCall` with `blocked="query_too_long"` so we can measure how often this fires.
- `capabilities.tools.search_docs.description` aligned with the tool-level description.

### Why
Semantic search is recall-poor on long keyword bundles (e.g. `"multiple environments devops content operations environments staging production development preview publishing workflow ci cd"`). Several short queries (`"content staging workflow"`, `"deployment environments"`, `"preview content before publishing"`) consistently return better-ranked articles. The descriptions help, but the word-count guard makes the steering load-bearing — models that ignore the description still get redirected.

---

## Test plan
- [x] Verified on `/docs/overview/cms-environments-development-and-content-workflow-best-practices`: all 5 figures render as real HTML; SVG with `<defs>`/`<marker>` paints; `<style>` block applies (183 CSS rules active); `<script>` IIFE runs (`data-active="true"` cycles through diagram nodes).
- [ ] Spot-check existing articles for no regressions in fenced-code rendering or normal markdown
- [ ] Check article column layout at `lg`, `xl`, and `2xl` viewports
- [ ] Manually invoke the MCP `search_docs` tool with a 14-word query and confirm the steering hint is returned without an Algolia call
- [ ] Confirm tool description renders correctly in the MCP client (line breaks, examples list)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
