### PR TITLE
fix(search): strip style/script contents from Algolia body

### DIFF
--- a/utils/searchUtils.js
+++ b/utils/searchUtils.js
@@ -203,6 +203,8 @@ const cleanMarkdown = (markdown) => {
     text = text.replace(/\[([^\]]+)\]\([^)]+\)/g, '$1');
     // Remove bare URLs
     text = text.replace(/https?:\/\/[^\s)]+/g, '');
+    // Remove <style> and <script> blocks including their contents
+    text = text.replace(/<(style|script)\b[^>]*>[\s\S]*?<\/\1>/gi, '');
     // Remove HTML tags
     text = text.replace(/<[^>]*>/g, '');
     // Remove heading markers


### PR DESCRIPTION
## Summary
- Strip `<style>` and `<script>` blocks (tag + contents) before the generic HTML-tag strip in `cleanMarkdown`, so CSS rules and inline JS no longer leak into the Algolia `body` field.

## Test plan
- [ ] Re-index an article that contains an inline `<style>` block and confirm the indexed `body` no longer contains CSS rules.
- [ ] Re-index an article with an inline `<script>` block and confirm the JS source is not in the indexed `body`.
- [ ] Spot-check that articles without embedded HTML still index normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
